### PR TITLE
fix: choose IPv6 address length when socket_family is AF_INET6

### DIFF
--- a/server.c
+++ b/server.c
@@ -478,7 +478,7 @@ static int receive_test_message(struct client_info *client, int session_index)
 {
     struct sockaddr_in addr;
     struct sockaddr_in6 addr6;
-    socklen_t len = sizeof(addr);
+    socklen_t len = (socket_family == AF_INET6)? sizeof(addr6) : sizeof(addr);
     char str_client[INET6_ADDRSTRLEN];
 
     inet_ntop(socket_family, (socket_family == AF_INET6)?

--- a/server.c
+++ b/server.c
@@ -573,9 +573,9 @@ static int receive_test_message(struct client_info *client, int session_index)
     }
 
     if(socket_family == AF_INET6) {
-        addr.sin_port = client->sessions[session_index].req.SenderPort;
-    } else {
         addr6.sin6_port = client->sessions[session_index].req.SenderPort;
+    } else {
+        addr.sin_port = client->sessions[session_index].req.SenderPort;
     }
     /* FW Loss Calculation */
 


### PR DESCRIPTION
Test packet replies has wrong IPv6 address at the end due to a wrong `msg_namelen`. It is always setting IPv4 length.

In this PR it chooses between IPv4 and IPv6 address length for `msg_namelen` depending on the socket family.